### PR TITLE
Adding support for element name in SimpleTypeException when a Validation Error occurs

### DIFF
--- a/project/api/src/main/java/org/genxdm/xs/exceptions/SimpleTypeException.java
+++ b/project/api/src/main/java/org/genxdm/xs/exceptions/SimpleTypeException.java
@@ -27,6 +27,7 @@ public final class SimpleTypeException extends SchemaException
     private final String initialValue;
     private final QName type;
     private final boolean isAnonymous;
+    private final QName elementName;
 
     public SimpleTypeException(final String initialValue, final SimpleType type, final SchemaException cause)
     {
@@ -34,8 +35,19 @@ public final class SimpleTypeException extends SchemaException
         this.initialValue = PreCondition.assertArgumentNotNull(initialValue, "initialValue");
         this.type = (type == null) ? null : type.getName();
         isAnonymous = (type == null) ? false : type.isAnonymous();
+        elementName = null;//Keep backward compatibility
     }
 
+    
+    public SimpleTypeException(final QName elementName, final String initialValue, final SimpleType type, final SchemaException cause)
+    {
+        super(ValidationOutcome.CVC_Simple_Type, "?", cause);
+        this.initialValue = PreCondition.assertArgumentNotNull(initialValue, "initialValue");
+        this.type = (type == null) ? null : type.getName();
+        isAnonymous = (type == null) ? false : type.isAnonymous();
+        this.elementName = elementName;
+    }
+    
     @Override
     public String getMessage()
     {
@@ -44,7 +56,13 @@ public final class SimpleTypeException extends SchemaException
             name = isAnonymous ? "{anonymous}" : type.toString();
         else
             name = "{unknown}";
-        final String localMessage = "The initial value '" + initialValue + "' is not valid with respect to the simple type definition '" + name + "'.";
+        String localMessage = null;
+        
+        if(elementName == null || !elementName.toString().isEmpty()){
+        	localMessage = "The initial value '" + initialValue +" for element "+ elementName +"' is not valid with respect to the simple type definition '" + name + "'.";
+        } else {
+        	localMessage = "The initial value '" + initialValue + "' is not valid with respect to the simple type definition '" + name + "'.";
+        }
 
         final StringBuilder message = new StringBuilder();
         // message.append(getOutcome().getSection());

--- a/project/api/src/main/java/org/genxdm/xs/exceptions/SimpleTypeException.java
+++ b/project/api/src/main/java/org/genxdm/xs/exceptions/SimpleTypeException.java
@@ -58,7 +58,7 @@ public final class SimpleTypeException extends SchemaException
             name = "{unknown}";
         String localMessage = null;
         
-        if(elementName == null || !elementName.toString().isEmpty()){
+        if(elementName != null || !elementName.toString().isEmpty()){
         	localMessage = "The initial value '" + initialValue +" for element "+ elementName +"' is not valid with respect to the simple type definition '" + name + "'.";
         } else {
         	localMessage = "The initial value '" + initialValue + "' is not valid with respect to the simple type definition '" + name + "'.";

--- a/project/processor.w3c.xs.validation/src/main/java/org/genxdm/processor/w3c/xs/validation/impl/ValidationKernel.java
+++ b/project/processor.w3c.xs.validation/src/main/java/org/genxdm/processor/w3c/xs/validation/impl/ValidationKernel.java
@@ -706,7 +706,11 @@ final class ValidationKernel<A> implements VxValidator<A>, SmExceptionSupplier
 						}
 						catch (final DatatypeException e)
 						{
-							m_errors.error(new SimpleTypeException(m_atomBridge.getC14NString(initialValue), simpleType, e));
+							if(declaration != null && declaration.getName() != null && !declaration.getName().toString().isEmpty()){ // Let's be extra cautious
+								m_errors.error(new SimpleTypeException(declaration.getName(),m_atomBridge.getC14NString(initialValue), simpleType, e));
+							} else {
+								m_errors.error(new SimpleTypeException(m_atomBridge.getC14NString(initialValue), simpleType, e));
+							}
 							if (null != m_downstream)
 							{
 								m_downstream.text(initialValue);


### PR DESCRIPTION
This fixes an issue reported by multiple customers where the element name was not being populated when validation error occurred.
Testing performed - Built the jars using maven and used in BW installation to test customer issue and see that element name is now printed along with the value. 
ValidationKernel has multiple lines where a new SimpleTypeException is thrown. If this fix is valid, I can submit changes for all the calls to new SimpleTypeException since in most calls we have the elementdeclaration with us.